### PR TITLE
Syntax fix

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,26 +1,27 @@
 class UsersController < ApplicationController
   # Nesse momento, o Rails cria a rota (route) e a view para a ação new, requisitada durante a
-  # criação do controller, também conhecida como sign up. 
+  # criação do controller, também conhecida como sign up.
   def new
-            @user = User.new
+    @user = User.new
   end
+
   def create
-            @user = User.new(user_params)
-            if @user.save
-                        redirect_to @user, notice: "Usuário foi criado com sucesso!"
-                        #tire o método de comentário quando criar o helper.
-                        #Usuário depois de cadastrar-se acessa o sistema automaticamente
-                        #sign_in(@user)
-            else 
-                render action: :new
-            end
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to @user, notice: "Usuário foi criado com sucesso!"
+      #tire o método de comentário quando criar o helper.
+      #Usuário depois de cadastrar-se acessa o sistema automaticamente
+      #sign_in(@user)
+    else
+      render action: :new
+    end
   end
 
   # É necessario fazer para evitar redundância e para da permissões.
-  # No Rails 4, começou a ser implementado o Strong parameters, onde são especificados 
+  # No Rails 4, começou a ser implementado o Strong parameters, onde são especificados
   # os parâmetros requeridos e permitidos, evitando a atribuição em massa.
   private
   def user_params
-            params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,22 @@
 class User < ApplicationRecord
     has_secure_password
-    validates name, presence: true, length: {maximum: 50}
-    validates password, presence: false, length: {minimum: 6}
-    VALID_EMAIL_FORMAT= /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i
-    validates email, presence: true, length: {maximum: 260}, format: { with: VALID_EMAIL_FORMAT}, uniqueness: {case_sensitive: false}
-    before_save { self.email = email.downcase }
+
+    VALID_EMAIL_FORMAT = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i
+
+    with_options presence: true do
+      validates :name, length: { maximum: 50 }
+      validates :password, length: { minimum: 6 }
+      validates :email,
+        length: { maximum: 260 },
+        format: { with: VALID_EMAIL_FORMAT},
+        uniqueness: { case_sensitive: false }
+    end
+
+    before_save { email_downcase }
+
+    private
+
+    def email_downcase
+      self.email.downcase!
+    end
 end


### PR DESCRIPTION
Os atributos devem er usados como símbolos nas validações. Você estava fazendo assim:

```ruby
validates name, presence: true
```

e o correto é assim:

```ruby
validates :name, presence: true
```

## O que fiz

* Para tabulação utilize 2 espaços
* Corrigi a sintaxe e fiz algumas pequenas melhorias anda de mais.